### PR TITLE
Use ^0.1.10 for peer dependency of typed-css-modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "css-modules"
   ],
   "peerDependencies": {
-    "typed-css-modules": "latest"
+    "typed-css-modules": "^0.1.10"
   },
   "author": "Oleg Stepura",
   "license": "MIT",


### PR DESCRIPTION
Fixes #2
