### PR TITLE
Support for DtsCreator parameters via query parameters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 npm-debug.log
+node_modules

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ const settings = {
       {
         test: /\.css$/,
         exclude: /node_modules/,
-        loader: 'typed-css-modules'
+        loader: 'typed-css-modules-loader'
       }
     ],
   }

--- a/README.md
+++ b/README.md
@@ -22,7 +22,9 @@ const settings = {
       {
         test: /\.css$/,
         exclude: /node_modules/,
-        loader: 'typed-css-modules-loader'
+        loader: 'typed-css-modules'
+        // or in case you want to use parameters:
+        // loader: 'typed-css-modules?option.outDir=/tmp'
       }
     ],
   }

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ const settings = {
       {
         test: /\.css$/,
         exclude: /node_modules/,
-        loader: 'typed-css-modules-loader'
+        loader: 'typed-css-modules'
       }
     ],
   }

--- a/README.md
+++ b/README.md
@@ -1,10 +1,16 @@
 # typed-css-modules-loader
 
 Simplest webpack loader for https://github.com/Quramy/typed-css-modules
-Has no configuration atm.
 
-I suggest using it as preloader. It will generate `.css.d.ts` files near the `.css`
-Please take a look at [this discussion](https://github.com/Quramy/typed-css-modules/issues/2) to make a decision.
+I suggest using it as preloader. Unless you change the options (see below), it
+will generate `.css.d.ts` files near the `.css`. Please take a look at
+[this discussion](https://github.com/Quramy/typed-css-modules/issues/2) to make a decision.
+
+You can affect how `typed-css-modules` behaves by using query parameters. The loader
+will pass on any query parameters you send give it to the constructor of the DtsCreator
+class. For more info on available options, have a look at the
+[DtsCreator constructor](https://github.com/Quramy/typed-css-modules#new-dtscreatoroption).
+
 
 ```js
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ const settings = {
         exclude: /node_modules/,
         loader: 'typed-css-modules'
         // or in case you want to use parameters:
-        // loader: 'typed-css-modules?option.outDir=/tmp'
+        // loader: 'typed-css-modules?outDir=/tmp'
       }
     ],
   }

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ will generate `.css.d.ts` files near the `.css`. Please take a look at
 [this discussion](https://github.com/Quramy/typed-css-modules/issues/2) to make a decision.
 
 You can affect how `typed-css-modules` behaves by using query parameters. The loader
-will pass on any query parameters you send give it to the constructor of the DtsCreator
-class. For more info on available options, have a look at the
+will pass any query parameters you specify to the constructor of the `DtsCreator`
+class. For more info on available options, please take a look here:
 [DtsCreator constructor](https://github.com/Quramy/typed-css-modules#new-dtscreatoroption).
 
 

--- a/index.js
+++ b/index.js
@@ -1,11 +1,22 @@
 var DtsCreator = require('typed-css-modules');
-
-var creator = new DtsCreator();
+var loaderUtils = require('loader-utils');
+var objectAssign = require('object-assign');
 
 module.exports = function(source, map) {
   this.cacheable && this.cacheable();
   var callback = this.async();
-  
+
+  // Pass on query parameters as an options object to the DtsCreator. This lets
+  // you change the default options of the DtsCreator and e.g. use a different
+  // output folder.
+  var queryOptions = loaderUtils.parseQuery(this.query);
+  var options;
+  if (queryOptions) {
+    options = objectAssign({}, queryOptions);
+  }
+
+  var creator = new DtsCreator(options);
+
   // creator.create(..., source) tells the module to operate on the
   // source variable. Check API for more details.
   creator.create(this.resourcePath, source).then(content => {

--- a/package.json
+++ b/package.json
@@ -22,5 +22,9 @@
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/olegstepura/typed-css-modules-loader/issues"
+  },
+  "dependencies": {
+    "loader-utils": "^0.2.15",
+    "object-assign": "^4.1.0"
   }
 }


### PR DESCRIPTION
This pull request adds support for passing options to the `DtsCreator` (typed-css-modules) instance via webkits query parameters. I might as well contribute the code here even though I ended up not needing it.
