### PR TITLE
Fixes initial, clean build in projects using this loader

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,6 +21,9 @@ module.exports = function(source, map) {
   // source variable. Check API for more details.
   creator.create(this.resourcePath, source).then(content => {
     content.writeFile().then(_ => {
+      // by emitting a dummy file for webpack we'll ensure that tsc actually
+      // knows it needs this file.
+      this.emitFile(content.outputFilePath, "");
       callback(null, source, map);
     });
   });


### PR DESCRIPTION
Because of how Webpack works, files created while `typed-css-modules-loader` executes aren't immediately visible to `ts-loader` what usually ends with a 'missing module' error the first time a project is built. 
The standard solution is just to rerun the build, but that's not really suitable for CI in larger projects, so here's my proposed solution - it just creates a dummy file withing Webpacks memory FS along the actual one, so Webpack can forward its filename to `ts-loader` and then to `tsc` which, in turn, will access the actual file on the OS FS. :smiley: 

[Here's](https://github.com/Idorobots/typescript-react-webpack-karma-electron-seed/blob/master/util/css-types-loader.js) a seed project, where I'm using a similar hack. I've also tested the same project with a patched local version of `typed-css-modules-loader` and it seems to work fine.
