### PR TITLE
Fix dependencies

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
 var DtsCreator = require('typed-css-modules');
 var loaderUtils = require('loader-utils');
-var objectAssign = require('object-assign');
 
 module.exports = function(source, map) {
   this.cacheable && this.cacheable();
@@ -12,7 +11,7 @@ module.exports = function(source, map) {
   var queryOptions = loaderUtils.parseQuery(this.query);
   var options;
   if (queryOptions) {
-    options = objectAssign({}, queryOptions);
+    options = Object.assign({}, queryOptions);
   }
 
   var creator = new DtsCreator(options);
@@ -25,4 +24,3 @@ module.exports = function(source, map) {
     });
   });
 };
-

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "css-modules"
   ],
   "peerDependencies": {
-    "typed-css-modules": "^0.1.10"
+    "typed-css-modules": "^0.2.0"
   },
   "author": "Oleg Stepura",
   "license": "MIT",
@@ -24,7 +24,6 @@
     "url": "https://github.com/olegstepura/typed-css-modules-loader/issues"
   },
   "dependencies": {
-    "loader-utils": "^0.2.15",
-    "object-assign": "^4.1.0"
+    "loader-utils": "^0.2.15"
   }
 }

--- a/package.json
+++ b/package.json
@@ -15,15 +15,13 @@
     "typed",
     "css-modules"
   ],
-  "peerDependencies": {
-    "typed-css-modules": "^0.2.0"
-  },
   "author": "Oleg Stepura",
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/olegstepura/typed-css-modules-loader/issues"
   },
   "dependencies": {
-    "loader-utils": "^0.2.15"
+    "loader-utils": "^0.2.15",
+    "typed-css-modules": "^0.2.0"
   }
 }


### PR DESCRIPTION
This patch fixes message `UNMET PEER DEPENDENCY typed-css-module`.

Also get rid of needless `object-assign` and use native `Object.assign`.