### PR TITLE
Add css resource as dependency to trigger rebuilds

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ var loaderUtils = require('loader-utils');
 
 module.exports = function(source, map) {
   this.cacheable && this.cacheable();
+  this.addDependency(this.resourcePath);
   var callback = this.async();
 
   // Pass on query parameters as an options object to the DtsCreator. This lets


### PR DESCRIPTION
Due to the `cachable` call and no `addDependency` changes are not rebuilt.
This doesn't add the transitive dependencies, but I'm not sure if this is really necessary.