### PR TITLE
Fixed passing of options to typed-css-modules

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ module.exports = function(source, map) {
   // Pass on query parameters as an options object to the DtsCreator. This lets
   // you change the default options of the DtsCreator and e.g. use a different
   // output folder.
-  var queryOptions = loaderUtils.getOptions(this.query);
+  var queryOptions = loaderUtils.getOptions(this);
   var options;
   if (queryOptions) {
     options = Object.assign({}, queryOptions);


### PR DESCRIPTION
I noticed that my options wasn't being passed to `typed-css-modules` after I updated to the latest version.

We should probably send in `this` directly instead of `this.query` to `loaderUtils.getOptions` or it would mean that we would have to write

```
{
    loader: "typed-css-modules-loader",
    options: {
        query: {
            rootDir: "src",
            searchDir: "styles"
        }
    }
}
```
instead of
```
{
    loader: "typed-css-modules-loader",
    options: {
        rootDir: "src",
        searchDir: "styles"
    }
}
```