### PR TITLE
Fix for webpack 2

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,8 +20,6 @@ module.exports = function(source, map) {
   // creator.create(..., source) tells the module to operate on the
   // source variable. Check API for more details.
   creator.create(this.resourcePath, source).then(content => {
-    // Emit the created content as well
-    this.emitFile(content.outputFilePath, content.contents || [''], map);
     content.writeFile().then(_ => {
       callback(null, source, map);
     });


### PR DESCRIPTION
Whith `this.emitFile(content.outputFilePath, content.contents || [''], map);` the webpack 2 stuck after first build