### PR TITLE
Use relative paths for emitted files

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+var path = require('path');
 var DtsCreator = require('typed-css-modules');
 var loaderUtils = require('loader-utils');
 
@@ -21,7 +22,7 @@ module.exports = function(source, map) {
   // source variable. Check API for more details.
   creator.create(this.resourcePath, source).then(content => {
     // Emit the created content as well
-    this.emitFile(content.outputFilePath, content.contents || [''], map);
+    this.emitFile(path.relative(this.options.context, content.outputFilePath), content.contents || [''], map);
     content.writeFile().then(_ => {
       callback(null, source, map);
     });


### PR DESCRIPTION
Currently the `typed-css-modules-loader` emits absolute file paths for all the virtual emitted webpack files, such as the following:

`/Users/tim/projects/foo/styles/index.css.d.ts`

As well as leaking information about the host system into the generated source maps, this also means that the bundled webpack artifact (and therefore its hash etc) will vary according to which user ran the build process.

This PR ensures that emitted file paths are all generated relative to the current webpack context root, such as the following:

`styles/index.css.d.ts`