### PR TITLE
Fix for noEmit

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,10 @@ class. For more info on available options, please take a look here:
 const settings = {
   // ...
   module: {
-    preLoaders: [
+    loaders: [
       // ...
       {
+        enforce: 'pre',
         test: /\.css$/,
         exclude: /node_modules/,
         loader: 'typed-css-modules'

--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ module.exports = function(source, map) {
   var emitFile = !options.noEmit;
   
   // Make sure to not modify options object directly
-  var creatorOptions = JSON.parse(JSON.stringify(options));
+  var creatorOptions = Object.assign({}, options);
   delete creatorOptions.noEmit;
 
   var creator = new DtsCreator(creatorOptions);

--- a/index.js
+++ b/index.js
@@ -13,9 +13,12 @@ module.exports = function(source, map) {
   var options = loaderUtils.getOptions(this) || {};
   var context = options.context || this.context || this.rootContext;
   var emitFile = !options.noEmit;
-  delete options.noEmit;
+  
+  // Make sure to not modify options object directly
+  var creatorOptions = JSON.parse(JSON.stringify(options));
+  delete creatorOptions.noEmit;
 
-  var creator = new DtsCreator(options);
+  var creator = new DtsCreator(creatorOptions);
 
   // creator.create(..., source) tells the module to operate on the
   // source variable. Check API for more details.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typed-css-modules-loader",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "description": "Webpack loader for typed-css-modules",
   "main": "index.js",
   "scripts": {
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/olegstepura/typed-css-modules-loader.git"
+    "url": "https://github.com/tomaskallup/typed-css-modules-loader.git"
   },
   "keywords": [
     "typescript",
@@ -18,7 +18,7 @@
   "author": "Oleg Stepura",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/olegstepura/typed-css-modules-loader/issues"
+    "url": "https://github.com/tomaskallup/typed-css-modules-loader/issues"
   },
   "dependencies": {
     "loader-utils": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/tomaskallup/typed-css-modules-loader.git"
+    "url": "https://github.com/olegstepura/typed-css-modules-loader.git"
   },
   "keywords": [
     "typescript",
@@ -18,7 +18,7 @@
   "author": "Oleg Stepura",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/tomaskallup/typed-css-modules-loader/issues"
+    "url": "https://github.com/olegstepura/typed-css-modules-loader/issues"
   },
   "dependencies": {
     "loader-utils": "^1.1.0",


### PR DESCRIPTION
Currently, the `noEmit` option is being deleted from the `options` object. 
This causes troubles if webpack is processing multiple files as it does not recreate the `options` and just reuses it so first file would not emit changes but subsequent would.

I've also made change to readme, where I updated the syntax for preloaders for new webpack.