### PR TITLE
loader name should be full module name

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ const settings = {
         enforce: 'pre',
         test: /\.css$/,
         exclude: /node_modules/,
-        loader: 'typed-css-modules'
+        loader: 'typed-css-modules-loader'
         // or in case you want to use parameters:
         // loader: 'typed-css-modules?outDir=/tmp'
         // or in case you want to use noEmit:


### PR DESCRIPTION
Since some version of webpack, loader property have to be specified with full module name.