### PR TITLE
Fix returning css.d.ts as empty file

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ module.exports = function(source, map) {
         // Emit the created content as well
         this.emitFile(
           path.relative(context, content.outputFilePath),
-          content.contents || [''],
+          content.formatted || '',
           map
         );
       }


### PR DESCRIPTION
[`this.emitFile`](https://webpack.js.org/api/loaders/#this-emitfile) only accepts Buffer or string content, but `content.contents` is a string array. I wonder how this was able to work before...?